### PR TITLE
Add webrick gem for local preview with jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 gemspec
 gem "github-pages", group: :jekyll_plugins
+gem "webrick", "~> 1.8"
 


### PR DESCRIPTION
I recommend adding `webrick` gem to the Gemfile. 
I use it in [previewing the page](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) locally, so if there's a different / better way to do this, or if no one actually previews the page, feel free to ignore this. 

As of ruby 3.0, `webrick` [is no longer bundled with ruby](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/). 